### PR TITLE
Introducing model tuning using TVM MetaSchedule

### DIFF
--- a/cm-mlops/script/get-generic-python-lib/_cm.json
+++ b/cm-mlops/script/get-generic-python-lib/_cm.json
@@ -42,7 +42,7 @@
       ],
       "env": {
         "CM_GENERIC_PYTHON_PACKAGE_NAME": "apache-tvm",
-        "CM_GENERIC_PYTHON_PIP_EXTRA": "--pre"
+        "CM_GENERIC_PYTHON_PIP_EXTRA": " --pre"
       },
       "new_env_keys": [
         "CM_APACHE_TVM_VERSION"
@@ -150,14 +150,6 @@
       },
       "new_env_keys": [
         "CM_ATTR_VERSION"
-      ]
-    },
-    "attrs": {
-      "env": {
-        "CM_GENERIC_PYTHON_PACKAGE_NAME": "attrs"
-      },
-      "new_env_keys": [
-        "CM_ATTRS_VERSION"
       ]
     },
     "decorator": {

--- a/cm-mlops/script/get-generic-python-lib/_cm.json
+++ b/cm-mlops/script/get-generic-python-lib/_cm.json
@@ -41,7 +41,8 @@
         }
       ],
       "env": {
-        "CM_GENERIC_PYTHON_PACKAGE_NAME": "apache-tvm"
+        "CM_GENERIC_PYTHON_PACKAGE_NAME": "apache-tvm",
+        "CM_GENERIC_PYTHON_PIP_EXTRA": "--pre"
       },
       "new_env_keys": [
         "CM_APACHE_TVM_VERSION"
@@ -739,6 +740,30 @@
       },
       "new_env_keys": [
         "CM_XLSXWRITER_VERSION"
+      ]
+    },
+    "xgboost": {
+      "env": {
+        "CM_GENERIC_PYTHON_PACKAGE_NAME": "xgboost"
+      },
+      "new_env_keys": [
+        "CM_XGBOOST_VERSION"
+      ]
+    },
+    "cloudpickle": {
+      "env": {
+        "CM_GENERIC_PYTHON_PACKAGE_NAME": "cloudpickle"
+      },
+      "new_env_keys": [
+        "CM_CLOUDPICKLE_VERSION"
+      ]
+    },
+    "tornado": {
+      "env": {
+        "CM_GENERIC_PYTHON_PACKAGE_NAME": "tornado"
+      },
+      "new_env_keys": [
+        "CM_TORNADO_VERSION"
       ]
     }
   }

--- a/cm-mlops/script/get-generic-python-lib/_cm.json
+++ b/cm-mlops/script/get-generic-python-lib/_cm.json
@@ -74,8 +74,10 @@
       ],
       "deps": [
         {
-          "names": [ "torch" ],
-	  "tags": "get,generic-python-lib,_torch_cuda"
+          "names": [
+            "torch"
+          ],
+          "tags": "get,generic-python-lib,_torch_cuda"
         }
       ]
     },
@@ -537,7 +539,7 @@
     },
     "pre": {
       "env": {
-	"CM_GENERIC_PYTHON_DEV_VERSION": "yes"
+        "CM_GENERIC_PYTHON_DEV_VERSION": "yes"
       }
     },
     "torch,pre": {
@@ -561,9 +563,9 @@
           ],
           "tags": "get,cuda"
         },
-	{
+        {
           "tags": "get,generic-python-lib,_numpy"
-	}
+        }
       ],
       "default_env": {
         "CM_GENERIC_PYTHON_PIP_UNINSTALL_DEPS": "torch_cuda"

--- a/cm-mlops/script/get-ml-model-resnet50-tvm/README.md
+++ b/cm-mlops/script/get-ml-model-resnet50-tvm/README.md
@@ -101,6 +101,25 @@ ___
 
 #### Variations
 
+  * *No group (any variation can be selected)*
+    <details>
+    <summary>Click here to expand this section.</summary>
+
+    * `_tune-model`
+      - Environment variables:
+        - *CM_TUNE_TVM_MODEL*: `yes`
+      - Workflow:
+        1. ***Read "deps" on other CM scripts***
+           * get,generic-python-lib,_xgboost
+             - CM script: [get-generic-python-lib](https://github.com/mlcommons/ck/tree/master/cm-mlops/script/get-generic-python-lib)
+           * get,generic-python-lib,_pandas
+             - CM script: [get-generic-python-lib](https://github.com/mlcommons/ck/tree/master/cm-mlops/script/get-generic-python-lib)
+           * get,generic-python-lib,_tornado
+             - CM script: [get-generic-python-lib](https://github.com/mlcommons/ck/tree/master/cm-mlops/script/get-generic-python-lib)
+
+    </details>
+
+
   * Group "**batchsize**"
     <details>
     <summary>Click here to expand this section.</summary>
@@ -174,6 +193,7 @@ ___
 These keys can be updated via --env.KEY=VALUE or "env" dictionary in @input.json or using script flags.
 
 * CM_ML_MODEL_MAX_BATCH_SIZE: **1**
+* CM_TUNE_TVM_MODEL: **no**
 
 </details>
 

--- a/cm-mlops/script/get-ml-model-resnet50-tvm/_cm.json
+++ b/cm-mlops/script/get-ml-model-resnet50-tvm/_cm.json
@@ -7,7 +7,8 @@
   "deps": [
     {
       "names": [
-        "python", "python3"
+        "python",
+        "python3"
       ],
       "tags": "get,python3"
     },
@@ -31,7 +32,8 @@
     }
   ],
   "default_env": {
-    "CM_ML_MODEL_MAX_BATCH_SIZE": "1"
+    "CM_ML_MODEL_MAX_BATCH_SIZE": "1",
+    "CM_TUNE_TVM_MODEL": "no"
   },
   "new_env_keys": [
     "CM_ML_MODEL_*"
@@ -130,6 +132,22 @@
     },
     "tflite": {
       "alias": "tensorflow"
+    },
+    "tune-model": {
+      "env": {
+        "CM_TUNE_TVM_MODEL": "yes"
+      },
+      "deps": [
+        {
+          "tags": "get,generic-python-lib,_xgboost"
+        },
+        {
+          "tags": "get,generic-python-lib,_pandas"
+        },
+        {
+          "tags": "get,generic-python-lib,_tornado"
+        }
+      ]
     },
     "batch_size.#": {
       "group": "batchsize",

--- a/cm-mlops/script/get-ml-model-resnet50-tvm/_cm.json
+++ b/cm-mlops/script/get-ml-model-resnet50-tvm/_cm.json
@@ -36,7 +36,8 @@
     "CM_TUNE_TVM_MODEL": "no"
   },
   "new_env_keys": [
-    "CM_ML_MODEL_*"
+    "CM_ML_MODEL_*",
+    "CM_TUNE_TVM_*"
   ],
   "tags": [
     "get",

--- a/cm-mlops/script/get-ml-model-resnet50-tvm/customize.py
+++ b/cm-mlops/script/get-ml-model-resnet50-tvm/customize.py
@@ -1,6 +1,7 @@
 from cmind import utils
 import os
 
+
 def preprocess(i):
 
     os_info = i['os_info']
@@ -11,15 +12,37 @@ def preprocess(i):
 
     cm = automation.cmind
 
-    return {'return':0}
+    work_dir = env.get('CM_TUNE_TVM_MODEL_WORKDIR', '')
+
+    if work_dir != '':
+        if not os.path.exists(work_dir):
+            raise FileNotFoundError(
+                f"Error: the specified path \"{work_dir}\"does not exist")
+
+        if not os.path.exists(f"{work_dir}/database_workload.json"):
+            raise FileNotFoundError(
+                "Error: the found workdir does not contain database_workload.json")
+
+        if not os.path.exists(f"{work_dir}/database_tuning_record.json"):
+            raise FileNotFoundError(
+                "Error: the found workdir does not contain database_tuning_record.json")
+
+        if env.get('CM_TUNE_TVM_MODEL', '') != '':
+            print("The \"tune-model\" variation is selected, but at the same time the path to the existing \"work_dir\" is also specified. The compiled model will be based on the found existing \"work_dir\".")
+            env["CM_TUNE_TVM_MODEL"] = "no"
+
+    return {'return': 0}
+
 
 def postprocess(i):
     env = i['env']
-    env['CM_ML_MODEL_ORIGINAL_FILE_WITH_PATH']= env['CM_ML_MODEL_FILE_WITH_PATH']
-    env['CM_ML_MODEL_FILE']='model-tvm.so'
+    env['CM_ML_MODEL_ORIGINAL_FILE_WITH_PATH'] = env['CM_ML_MODEL_FILE_WITH_PATH']
+    env['CM_ML_MODEL_FILE'] = 'model-tvm.so'
     env['CM_ML_MODEL_PATH'] = os.path.join(os.getcwd())
-    env['CM_ML_MODEL_FILE_WITH_PATH'] = os.path.join(os.getcwd(), env['CM_ML_MODEL_FILE'])
-    env['CM_ML_MODEL_FRAMEWORK'] = "tvm-"+env['CM_ML_MODEL_FRAMEWORK']
-    env['CM_ML_MODEL_INPUT_SHAPES'] = env['CM_ML_MODEL_INPUT_SHAPES'].replace("BATCH_SIZE", env['CM_ML_MODEL_MAX_BATCH_SIZE'])
+    env['CM_ML_MODEL_FILE_WITH_PATH'] = os.path.join(
+        os.getcwd(), env['CM_ML_MODEL_FILE'])
+    env['CM_ML_MODEL_FRAMEWORK'] = "tvm-" + env['CM_ML_MODEL_FRAMEWORK']
+    env['CM_ML_MODEL_INPUT_SHAPES'] = env['CM_ML_MODEL_INPUT_SHAPES'].replace(
+        "BATCH_SIZE", env['CM_ML_MODEL_MAX_BATCH_SIZE'])
 
-    return {'return':0}
+    return {'return': 0}

--- a/cm-mlops/script/get-ml-model-resnet50-tvm/process.py
+++ b/cm-mlops/script/get-ml-model-resnet50-tvm/process.py
@@ -147,10 +147,9 @@ else:
             tasks=tasks,
             task_weights=task_weights,
             work_dir=work_dir,
-            # max_trials_global=20000,
-            max_trials_global=200,
-            num_trials_per_iter=10,
-            max_trials_per_task=10,
+            max_trials_global=20000,
+            num_trials_per_iter=64,
+            max_trials_per_task=256,
             builder=ms.builder.LocalBuilder(),
             runner=ms.runner.LocalRunner(evaluator_config=evaluator_config),
         )
@@ -158,8 +157,10 @@ else:
         database = ms.database.JSONDatabase(f"{work_dir}/database_workload.json",
                                             f"{work_dir}/database_tuning_record.json",
                                             allow_missing=False)
+        
+        build_conf["relay.backend.use_meta_schedule"] = True
 
-        with tvm.transform.PassContext(opt_level=opt_lvl):
+        with tvm.transform.PassContext(opt_level=opt_lvl, config=build_conf):
             lib = ms.relay_integration.compile_relay(
                 database, mod, tvm_target, params)
 

--- a/cm-mlops/script/get-ml-model-resnet50-tvm/process.py
+++ b/cm-mlops/script/get-ml-model-resnet50-tvm/process.py
@@ -1,141 +1,172 @@
 import os
 import tvm
-# Import model to TVM
 from tvm import relay
+
 max_batchsize = os.environ['CM_ML_MODEL_MAX_BATCH_SIZE']
-input_shapes = os.environ.get('CM_ML_MODEL_INPUT_SHAPES','').strip()
+input_shapes = os.environ.get('CM_ML_MODEL_INPUT_SHAPES', '').strip()
+
 if input_shapes == '':
-    print ('')
-    raise Exception("Error: CM_ML_MODEL_INPUT_SHAPES environment variable is not defined!")
+    print('')
+    raise Exception(
+        "Error: CM_ML_MODEL_INPUT_SHAPES environment variable is not defined!")
 
 input_shapes = input_shapes.replace('BATCH_SIZE', str(max_batchsize))
 model_path = os.environ.get('CM_ML_MODEL_FILE_WITH_PATH')
 
-print ('TVM model: '+model_path)
+print('TVM model: ' + model_path)
 # Check if load precompiled model
 compiled_model = os.path.join(os.getcwd(), 'model-tvm.so')
 if model_path.endswith('.so') or model_path.endswith('.dylib'):
     compiled_model = model_path
 
     if not os.path.isfile(compiled_model):
-        print ('')
+        print('')
         raise Exception("Error: Model file {} not found!".format(compiled_model))
-
-
-build_conf = {}
-params = {}
-
-if model_path.endswith('.pt'):
-   import torch
-   from tvm.relay.build_module import bind_params_by_name
-
-   shape_list = eval('[' + input_shapes + ']')
-
-   print ('TVM shape list: '+str(shape_list))
-
-   x=os.environ.get('CM_MLPERF_TVM_TORCH_QUANTIZED_ENGINE','')
-   if x!='':
-       torch.backends.quantized.engine = x
-   pytorch_model = torch.jit.load(model_path)
-   pytorch_model.eval()
-
-   mod, params = relay.frontend.from_pytorch(pytorch_model, shape_list)
-
-   mod["main"] = bind_params_by_name(mod["main"], params)
-
-   # Some optimizations
-   mod = relay.transform.FoldConstant()(mod)
-
-   if os.environ.get('CM_MLPERF_TVM_USE_DNNL','').strip().lower() == 'yes':
-      from tvm.relay.op.contrib.dnnl import partition_for_dnnl
-      from tvm.driver.tvmc.common import convert_graph_layout
-
-      #  move to NHWC layout, prerequisite for DNNL partitioning
-      mod = convert_graph_layout(mod, "NHWC")
-      mod = relay.transform.FoldConstant()(mod)
-
-      mod = partition_for_dnnl(mod)
-
-elif model_path.endswith('.onnx'):
-   import onnx
-
-   shape_dict = eval('{' + input_shapes + '}')
-
-   print ('TVM shape dict: '+str(shape_dict))
-
-   onnx_model = onnx.load(model_path)
-
-   mod, params = relay.frontend.from_onnx(onnx_model, shape_dict, freeze_params=True)
-
-   # Some optimizations
-   mod = relay.transform.DynamicToStatic()(mod)
-   #mod = relay.transform.FoldExplicitPadding()(mod)
-
-   if os.environ.get('CM_MLPERF_TVM_TRANSFORM_LAYOUT','').strip().lower() == 'yes':
-      kernel_layout='NHWC'
-
-      desired_layouts = {
-              'qnn.conv2d': [kernel_layout, 'default'],
-              'nn.conv2d': [kernel_layout, 'default'],
-              'nn.conv2d_transpose': [kernel_layout, 'default'],
-              'nn.depthwise_conv2d': [kernel_layout, 'default'],
-              'nn.conv3d': [kernel_layout, 'default'],
-              'nn.conv3d_transpose': [kernel_layout, 'default'],
-              }
-
-      seq = tvm.transform.Sequential([relay.transform.RemoveUnusedFunctions(),
-          relay.transform.FoldConstant(),
-          relay.transform.ConvertLayout(desired_layouts),
-          ])
-
-      with tvm.transform.PassContext(opt_level=3):
-          mod = seq(mod)
-
-elif model_path.endswith('.tflite'):
-   # Grigori used https://tvm.apache.org/docs/tutorials/frontend/deploy_prequantized_tflite.html
-
-   import tflite
-
-   shape_dict = eval('{' + input_shapes + '}')
-
-   print ('TVM shape dict: '+str(shape_dict))
-
-   tflite_model_buf = open(model_path, "rb").read()
-   tflite_model = tflite.Model.GetRootAsModel(tflite_model_buf, 0)
-
-   mod, params = relay.frontend.from_tflite(tflite_model, shape_dict)
-
 else:
-   print ('')
-   raise Exception("Error: model extension is not supported in TVM backend ({})!".format(model_path))
 
-          # Build model
-# TBD! Apply autotuning history!
-opt_lvl = int(os.environ.get('CM_MLPERF_TVM_OPT_LEVEL', 3))
+    build_conf = {}
+    params = {}
 
-target = os.environ.get('CM_MLPERF_TVM_TARGET', 'llvm')
+    if model_path.endswith('.pt'):
+        import torch
+        from tvm.relay.build_module import bind_params_by_name
 
-target_host=None
+        shape_list = eval('[' + input_shapes + ']')
 
-# New target API
-tvm_target = tvm.target.Target(target, host=target_host)
+        print('TVM shape list: '+str(shape_list))
 
-# Check if apply history
-tvm_history_json_file = os.environ.get('CM_MLPERF_TVM_APPLY_HISTORY','').strip()
-if tvm_history_json_file!='':
-    if not os.path.isfile(tvm_history_json_file):
-        print ('')
-        raise Exception("Error: TVM history file {} not found!".format(tvm_history_json_file))
+        x = os.environ.get('CM_MLPERF_TVM_TORCH_QUANTIZED_ENGINE', '')
+        if x != '':
+            torch.backends.quantized.engine = x
+        pytorch_model = torch.jit.load(model_path)
+        pytorch_model.eval()
 
-    build_conf['relay.backend.use_auto_scheduler']=True
+        mod, params = relay.frontend.from_pytorch(pytorch_model, shape_list)
 
-    with auto_scheduler.ApplyHistoryBest(tvm_history_json_file):
-       with tvm.transform.PassContext(opt_level=opt_lvl, config=build_conf):
-           lib=relay.build(mod, target=tvm_target, params=params)
-else:
-    with tvm.transform.PassContext(opt_level=opt_lvl, config=build_conf):
-        lib=relay.build(mod, target=tvm_target, params=params)
+        mod["main"] = bind_params_by_name(mod["main"], params)
 
-lib.export_library(compiled_model)
+        # Some optimizations
+        mod = relay.transform.FoldConstant()(mod)
 
-print ('TVM compiled model: '+compiled_model)
+        if os.environ.get('CM_MLPERF_TVM_USE_DNNL', '').strip().lower() == 'yes':
+            from tvm.relay.op.contrib.dnnl import partition_for_dnnl
+            from tvm.driver.tvmc.common import convert_graph_layout
+
+            #  move to NHWC layout, prerequisite for DNNL partitioning
+            mod = convert_graph_layout(mod, "NHWC")
+            mod = relay.transform.FoldConstant()(mod)
+
+            mod = partition_for_dnnl(mod)
+
+    elif model_path.endswith('.onnx'):
+        import onnx
+
+        shape_dict = eval('{' + input_shapes + '}')
+
+        print('TVM shape dict: '+str(shape_dict))
+
+        onnx_model = onnx.load(model_path)
+
+        mod, params = relay.frontend.from_onnx(
+            onnx_model, shape_dict, freeze_params=True)
+
+        # Some optimizations
+        mod = relay.transform.DynamicToStatic()(mod)
+        # mod = relay.transform.FoldExplicitPadding()(mod)
+
+        if os.environ.get('CM_MLPERF_TVM_TRANSFORM_LAYOUT', '').strip().lower() == 'yes':
+            kernel_layout = 'NHWC'
+
+            desired_layouts = {
+                'qnn.conv2d': [kernel_layout, 'default'],
+                'nn.conv2d': [kernel_layout, 'default'],
+                'nn.conv2d_transpose': [kernel_layout, 'default'],
+                'nn.depthwise_conv2d': [kernel_layout, 'default'],
+                'nn.conv3d': [kernel_layout, 'default'],
+                'nn.conv3d_transpose': [kernel_layout, 'default'],
+            }
+
+            seq = tvm.transform.Sequential([relay.transform.RemoveUnusedFunctions(),
+                                            relay.transform.FoldConstant(),
+                                            relay.transform.ConvertLayout(
+                                                desired_layouts),
+                                            ])
+
+            with tvm.transform.PassContext(opt_level=3):
+                mod = seq(mod)
+
+    elif model_path.endswith('.tflite'):
+        # Grigori used https://tvm.apache.org/docs/tutorials/frontend/deploy_prequantized_tflite.html
+
+        import tflite
+
+        shape_dict = eval('{' + input_shapes + '}')
+
+        print('TVM shape dict: '+str(shape_dict))
+
+        tflite_model_buf = open(model_path, "rb").read()
+        tflite_model = tflite.Model.GetRootAsModel(tflite_model_buf, 0)
+
+        mod, params = relay.frontend.from_tflite(tflite_model, shape_dict)
+
+    else:
+        print('')
+        raise Exception(
+            "Error: model extension is not supported in TVM backend ({})!".format(model_path))
+
+    opt_lvl = int(os.environ.get('CM_MLPERF_TVM_OPT_LEVEL', 3))
+
+    target = os.environ.get('CM_MLPERF_TVM_TARGET',
+                            f"llvm -num-cores {os.environ.get('CM_HOST_CPU_TOTAL_CORES', '1')}")
+
+    target_host = None
+
+    # New target API
+    tvm_target = tvm.target.Target(target, host=target_host)
+
+    if os.environ.get('CM_TUNE_TVM_MODEL', 'no') == 'yes':
+        from tvm import meta_schedule as ms
+
+        work_dir = os.path.join(os.getcwd(), "metaschedule_workdir")
+        if not os.path.exists(work_dir):
+            os.mkdir(work_dir)
+
+        print("Extracting tasks...")
+        extracted_tasks = ms.relay_integration.extract_tasks(
+            mod, tvm_target, params
+        )
+        tasks, task_weights = ms.relay_integration.extracted_tasks_to_tune_contexts(
+            extracted_tasks, work_dir, strategy="evolutionary"
+        )
+
+        print("Begin tuning...")
+        evaluator_config = ms.runner.config.EvaluatorConfig(
+            number=1, repeat=10, enable_cpu_cache_flush=True
+        )
+        database = ms.tune.tune_tasks(
+            tasks=tasks,
+            task_weights=task_weights,
+            work_dir=work_dir,
+            # max_trials_global=20000,
+            max_trials_global=200,
+            num_trials_per_iter=10,
+            max_trials_per_task=10,
+            builder=ms.builder.LocalBuilder(),
+            runner=ms.runner.LocalRunner(evaluator_config=evaluator_config),
+        )
+
+        database = ms.database.JSONDatabase(f"{work_dir}/database_workload.json",
+                                            f"{work_dir}/database_tuning_record.json",
+                                            allow_missing=False)
+
+        with tvm.transform.PassContext(opt_level=opt_lvl):
+            lib = ms.relay_integration.compile_relay(
+                database, mod, tvm_target, params)
+
+    else:
+        with tvm.transform.PassContext(opt_level=opt_lvl, config=build_conf):
+            lib = relay.build(mod, target=tvm_target, params=params)
+
+    lib.export_library(compiled_model)
+
+    print('TVM compiled model: ' + compiled_model)


### PR DESCRIPTION
Added variation `tune-model` for `get-ml-model-resnet50-tvm` to tune ResNet50 using MetaSchedule. Also it is possible to compile model using already existing tuning records