### PR TITLE
V1.3.0

### DIFF
--- a/cm-mlops/automation/script/module.py
+++ b/cm-mlops/automation/script/module.py
@@ -145,8 +145,8 @@ class CAutomation(Automation):
           (debug_script) (bool): if True, debug current script (set debug_script_tags to the tags of a current script)
           (detected_versions) (dict): All the used scripts and their detected_versions
 
-          (silent) (bool): if True, hides all tech. info about script execution (no verbose)
-          (s) (bool): the same as silent
+          (verbose) (bool): if True, prints all tech. info about script execution (False by default)
+          (v) (bool): the same as verbose
 
           (time) (bool): if True, print script execution time (on if verbose == True)
 
@@ -237,10 +237,13 @@ class CAutomation(Automation):
 
         print_env = i.get('print_env', False)
 
-        #verbose = i.get('verbose', False)
-        #if not verbose: verbose = i.get('v', False)
-        verbose = not i.get('silent', False)
-        if verbose: verbose = not i.get('s', False)
+        verbose = False
+
+        if 'verbose' in i: verbose=i['verbose']
+        elif 'v' in i: verbose=i['v']
+
+        if verbose:
+           env['CM_VERBOSE']='yes'
 
         show_time = i.get('time', False)
 
@@ -2357,8 +2360,7 @@ class CAutomation(Automation):
                             'const_state':const_state,
                             'add_deps_recursive':add_deps_recursive,
                             'debug_script_tags':debug_script_tags,
-# Not used anymore                            'verbose':verbose,
-                            'silent':not verbose,
+                            'verbose':verbose,
                             'time':show_time,
                             'run_state':run_state
 

--- a/cm-mlops/script/download-file/customize.py
+++ b/cm-mlops/script/download-file/customize.py
@@ -25,6 +25,7 @@ def preprocess(i):
     url = env['CM_DOWNLOAD_URL']
     extra_download_options = env.get('CM_DOWNLOAD_EXTRA_OPTIONS', '')
 
+    print ('')
     if env['CM_DOWNLOAD_TOOL'] == "cmutil":
         cm = automation.cmind
         r = cm.access({'action':'download_file',

--- a/cm-mlops/script/get-dataset-imagenet-aux/run.bat
+++ b/cm-mlops/script/get-dataset-imagenet-aux/run.bat
@@ -1,3 +1,5 @@
+echo.
+
 wget -nc %CM_WGET_URL% --no-check-certificate
 IF %ERRORLEVEL% NEQ 0 EXIT 1
 

--- a/cm-mlops/script/get-dataset-imagenet-aux/run.sh
+++ b/cm-mlops/script/get-dataset-imagenet-aux/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo ""
+
 wget -4 -nc ${CM_WGET_URL} --no-check-certificate
 test $? -eq 0 || exit 1
 

--- a/cm-mlops/script/get-dataset-imagenet-val/run.bat
+++ b/cm-mlops/script/get-dataset-imagenet-val/run.bat
@@ -1,4 +1,6 @@
 if "%CM_DATASET_PATH%" == "" (
+  echo.
+
   wget -nc https://www.dropbox.com/s/57s11df6pts3z69/ILSVRC2012_img_val_500.tar --no-check-certificate
   IF %ERRORLEVEL% NEQ 0 EXIT 1
 

--- a/cm-mlops/script/get-generic-python-lib/customize.py
+++ b/cm-mlops/script/get-generic-python-lib/customize.py
@@ -25,7 +25,7 @@ def preprocess(i):
     env['CM_TMP_PYTHON_PACKAGE_NAME_ENV'] = prepare_env_key.upper()
 
     recursion_spaces = i['recursion_spaces']
-
+    
     r = automation.detect_version_using_script({
                'env': env,
                'run_script_input':i['run_script_input'],
@@ -70,16 +70,22 @@ def preprocess(i):
     return {'return':0}
 
 def detect_version(i):
+
     env = i['env']
+
+    env_version_key = 'CM_'+env['CM_TMP_PYTHON_PACKAGE_NAME_ENV'].upper()+'_VERSION'
+
     r = i['automation'].parse_version({'match_text': r'\s*([\d.a-z\-]+)',
                                        'group_number': 1,
-                                       'env_key':'CM_'+env['CM_TMP_PYTHON_PACKAGE_NAME_ENV'].upper()+'_VERSION',
+                                       'env_key':env_version_key,
                                        'which_env':i['env']})
     if r['return'] >0: return r
 
     version = r['version']
+    current_detected_version = version
 
     print (i['recursion_spaces'] + '      Detected version: {}'.format(version))
+
     return {'return':0, 'version':version}
 
 
@@ -87,10 +93,15 @@ def postprocess(i):
 
     env = i['env']
 
-    r = detect_version(i)
-    if r['return'] >0: return r
+    env_version_key = 'CM_'+env['CM_TMP_PYTHON_PACKAGE_NAME_ENV'].upper()+'_VERSION'
 
-    version = r['version']
+    if env.get(env_version_key,'')!='':
+        version = env[env_version_key]
+    else:
+        r = detect_version(i)
+        if r['return'] >0: return r
+
+        version = r['version']
 
     env['CM_PYTHONLIB_'+env['CM_TMP_PYTHON_PACKAGE_NAME_ENV']+'_CACHE_TAGS'] = 'version-'+version
 

--- a/cm-mlops/script/test-mlperf-inference-retinanet-win/run.bat
+++ b/cm-mlops/script/test-mlperf-inference-retinanet-win/run.bat
@@ -1,4 +1,4 @@
-@echo off
+echo.
 
 set CUR_DIR=%cd%
 set SCRIPT_DIR=%CM_TMP_CURRENT_SCRIPT_PATH%

--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,3 +1,10 @@
+## V1.3.0
+   - Turned on artifact indexing by default 
+     (can be turned off by setting CM_INDEX to "no", "off" or "false")
+   - Turned on --silent mode in "cm run script" by default
+     Can be turned off via --verbose or -v flags
+   - Fixed duplicate version detection for Python packages
+
 ## V1.2.2
    - Fixed minor bug during cm detect repo (turn off indexing)
 

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.2"
+__version__ = "1.3.0"
 
 from cmind.core import access
 from cmind.core import error

--- a/cm/cmind/core.py
+++ b/cm/cmind/core.py
@@ -103,9 +103,9 @@ class CM(object):
         # Index
         self.index = None
 
-        self.use_index = False
-        if os.environ.get(self.cfg['env_index'],'').strip().lower() in ['yes','on','true']:
-            self.use_index = True
+        self.use_index = True
+        if os.environ.get(self.cfg['env_index'],'').strip().lower() in ['no','off','false']:
+            self.use_index = False
 
     ############################################################
     def error(self, r):

--- a/cmr.yaml
+++ b/cmr.yaml
@@ -2,4 +2,4 @@ alias: mlcommons@ck
 git: true
 prefix: cm-mlops
 uid: a4705959af8e447a
-version: 1.2.1
+version: 1.3.0

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,8 +149,8 @@ You can use the following environment variables to customize CM installation:
 * `'CM_HOME'` - change path to the CM python package with the default 'repo' directory.
   Useful to improve the default automations inside the CM package.
 
-* `'CM_INDEX'` (*CM v1.2.0+*) - set to {on|yes|true} to turn on CM indexing of all artifacts
-  to speed up search and scripts by 10..50x.
+* `'CM_INDEX'` (*CM v1.3.0+*) - set to {off|no|false} to turn off CM indexing of all artifacts
+  (when on, it speeds up artifact searching and execution of CM scripts by 10..50x)
 
 
 


### PR DESCRIPTION
V1.3.0
   - Turned on artifact indexing by default 
     (can be turned off by setting CM_INDEX to "no", "off" or "false")
   - Turned on --silent mode in "cm run script" by default
     Can be turned off via --verbose or -v flags
   - Fixed duplicate version detection for Python packages
