### PR TITLE
Change batchsize for tvm backend

### DIFF
--- a/cm-mlops/script/app-mlperf-inference/_cm.yaml
+++ b/cm-mlops/script/app-mlperf-inference/_cm.yaml
@@ -592,7 +592,7 @@ variations:
   tvm-onnx:
     group: backend
     base:
-      - batch_size.32
+      - batch_size.1
     env:
       CM_MLPERF_BACKEND: tvm-onnx
     add_deps_recursive:

--- a/cm-mlops/script/get-tvm-model/process.py
+++ b/cm-mlops/script/get-tvm-model/process.py
@@ -87,7 +87,7 @@ def tune_model(
         tasks=tasks,
         task_weights=task_weights,
         work_dir=work_dir,
-        max_trials_global=20000,
+        max_trials_global=10000,
         num_trials_per_iter=64,
         max_trials_per_task=512,
         builder=ms.builder.LocalBuilder(),


### PR DESCRIPTION
Changed `batch_size` and decrease maximum number of trials for tuning for `tvm` backend