### PR TITLE
Non-interactive package install on Ubuntu

### DIFF
--- a/cm-mlops/script/get-sys-utils-cm/run-ubuntu.sh
+++ b/cm-mlops/script/get-sys-utils-cm/run-ubuntu.sh
@@ -14,7 +14,7 @@ fi
 CM_APT_TOOL=${CM_APT_TOOL:-apt-get}
 
 ${CM_SUDO} ${CM_APT_TOOL} update && \
-    ${CM_SUDO} ${CM_APT_TOOL} install -y --no-install-recommends \
+    ${CM_SUDO} DEBIAN_FRONTEND=noninteractive ${CM_APT_TOOL} install -y --no-install-recommends \
            apt-utils \
            git \
            wget \


### PR DESCRIPTION
When running the command manually it is already non-interactive, but for some reason when running this from a script (from cloud-init if that matters), the install of packages remains stuck on an interactive prompt.