### PR TITLE
Non-interactive apt-get

### DIFF
--- a/cm-mlops/script/detect-os/customize.py
+++ b/cm-mlops/script/detect-os/customize.py
@@ -73,7 +73,7 @@ def postprocess(i):
         if env.get('CM_HOST_OS_FLAVOR','') == "sles":
             env['CM_HOST_OS_PACKAGE_MANAGER'] = "zypper"
     if env.get('CM_HOST_OS_PACKAGE_MANAGER', '') == "apt":
-        env['CM_HOST_OS_PACKAGE_MANAGER_INSTALL_CMD'] = "apt-get install -y"
+        env['CM_HOST_OS_PACKAGE_MANAGER_INSTALL_CMD'] = "DEBIAN_FRONTEND=noninteractive apt-get install -y"
         env['CM_HOST_OS_PACKAGE_MANAGER_UPDATE_CMD'] = "apt-get update -y"
     elif env.get('CM_HOST_OS_PACKAGE_MANAGER', '') == "dnf":
         env['CM_HOST_OS_PACKAGE_MANAGER_INSTALL_CMD'] = "dnf install -y"


### PR DESCRIPTION
This needs to be set at the command level, because it is sometimes called with sudo which drops the environment.

This breaks a bit the format of this file, but I don't see a cleaner way to pass this.