### PR TITLE
added core.debug and env CM_CORE_SKIP_FIX_REPO_PATH

### DIFF
--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,3 +1,7 @@
+## V2.3.6.1
+   - added cmind.core.debug to make it easier to debug CM automations
+   - added env CM_CORE_SKIP_FIX_REPO_PATH to skip fixing non-existent repo paths
+
 ## V2.3.6
    - fixed "cm init" on Windows (do not check wget and curl - managed via CM scripts)
  

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -2,7 +2,7 @@
 #
 # Written by Grigori Fursin
 
-__version__ = "2.3.6"
+__version__ = "2.3.6.1"
 
 from cmind.core import access
 from cmind.core import error

--- a/cm/cmind/core.py
+++ b/cm/cmind/core.py
@@ -818,3 +818,39 @@ def get_version():
     r['version'] = version
 
     return r
+
+##############################################################################
+def debug(path_to_cm_automation_module):
+
+    import cmind
+
+    import os
+    automation = os.path.basename(os.path.dirname(path_to_cm_automation_module))
+
+    import sys
+    argv = sys.argv[1:]
+
+    # If run from VS, length == 1
+
+    # else normal argv
+
+    if len(argv) == 0:
+       cmd = 'test ' + automation
+    elif len(argv) == 1:
+       cmd = argv[0]
+
+       if ' ' not in cmd:
+           cmd += ' ' + automation
+       else:
+           space_index = cmd.find(' ')
+           cmd = cmd[:space_index] + ' ' + automation + ' ' + cmd[space_index+1:]
+    else:
+       cmd = argv
+       cmd.insert(1, automation)
+
+    print ('')
+    print ('Envoking CM command:')
+    print (f'{cmd}')
+
+    print ('')
+    return cmind.access(cmd)

--- a/cm/cmind/repos.py
+++ b/cm/cmind/repos.py
@@ -154,18 +154,21 @@ class Repos:
                 print ('WARNING: repository path {} not found (check file {})'.format(path_to_repo, full_path_to_repo_paths))
 
         # Save with correct paths
-        if len(checked_self_paths)!=len(self.paths):
-            import copy
+        if len(checked_self_paths) != len(self.paths):
 
-            self.paths = copy.deepcopy(checked_self_paths)
+            skip_fix_paths = os.environ.get('CM_CORE_SKIP_FIX_REPO_PATH','').strip().lower()
+            if skip_fix_paths not in ['1', 'true', 'yes']:
+                import copy
 
-            if self.path_to_internal_repo in checked_self_paths:
-                checked_self_paths.remove(self.path_to_internal_repo)
+                self.paths = copy.deepcopy(checked_self_paths)
 
-            print ('WARNING: fixed repo list file {}'.format(full_path_to_repo_paths))
+                if self.path_to_internal_repo in checked_self_paths:
+                    checked_self_paths.remove(self.path_to_internal_repo)
 
-            r = utils.save_json(full_path_to_repo_paths, meta = checked_self_paths)
-            if r['return']>0: return r
+                print ('WARNING: fixed repo list file {}'.format(full_path_to_repo_paths))
+
+                r = utils.save_json(full_path_to_repo_paths, meta = checked_self_paths)
+                if r['return']>0: return r
 
         return {'return':0}
 


### PR DESCRIPTION
## V2.3.6.1
   - added cmind.core.debug to make it easier to debug CM automations
   - added env CM_CORE_SKIP_FIX_REPO_PATH to skip fixing non-existent repo paths
