### PR TITLE
Added install_python_requirements to the CM repo description

### DIFF
--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,3 +1,7 @@
+## V2.3.9.1
+   - added `install_python_requirements` to the CM repo description (cmr.yaml)
+     to install requirements to a current python with CM installation if needed
+
 ## V2.3.9
    - added `--min` == `--skip` to `cm init` for readability
    - added `--checkout` to `cm init` to handle checkout

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -2,7 +2,7 @@
 #
 # Written by Grigori Fursin
 
-__version__ = "2.3.9"
+__version__ = "2.3.9.1"
 
 from cmind.core import access
 from cmind.core import error

--- a/cm/cmind/repos.py
+++ b/cm/cmind/repos.py
@@ -547,6 +547,26 @@ class Repos:
 
         warnings = r.get('warnings', [])
 
+        # Check if need to install requirements
+        install_python_requirements = meta.get('install_python_requirements', False)
+
+        if install_python_requirements:
+            import sys
+
+            python_exec = sys.executable
+
+            cmd = python_exec + ' -m pip install -r requirements.txt'
+
+            if console:
+                print ('')
+                print (cmd)
+                print ('')
+
+            r = os.system(cmd)
+
+            if r>0:
+                return {'return':1, 'error':'pip install -r requirements failed for this CM repository'}
+
         # Go back to original directory
         os.chdir(cur_dir)
 


### PR DESCRIPTION
We got requests to install extra PIP packages when pulling CM repositories. This flag will force to install extra dependencies from requirements.txt file when pulling such CM repositories ...
