### PR TITLE
v2.4.0: added support to install requirements.txt from pulled CM repositories

### DIFF
--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,4 +1,4 @@
-## V2.3.9.1
+## V2.4.0
    - added `install_python_requirements` to the CM repo description (cmr.yaml)
      to install requirements to a current python with CM installation if needed
 

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -2,7 +2,7 @@
 #
 # Written by Grigori Fursin
 
-__version__ = "2.3.9.1"
+__version__ = "2.4.0"
 
 from cmind.core import access
 from cmind.core import error


### PR DESCRIPTION
Hi @arjunsuresh and @anandhu-eng,

This release has a nice feature to install `requirements.txt` from pulled CM repositories if `_cm.yaml` has `install_python_requirements: true`

It should be backwards compatible and was based on several requests I received in the past few months.

Feel free to use it if needed ...

Thank you and have a good weekend!
