### PR TITLE
V3.2.0: many important improvements

### DIFF
--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,5 +1,15 @@
 ## V3.1.0.1
+   - added `utils.test_input` to test if input has keys
+     and report them as error
    - added `prefix_cmx` key to cmr.yaml to customize `cmx pull repo`
+   - improved CMX logging (-log and -logfile):
+     https://github.com/mlcommons/ck/issues/1317
+   - print control flags in help (cmx -h | cmx -help):
+     https://github.com/mlcommons/ck/issues/1318
+   - fail if control flag is not recognized:
+     https://github.com/mlcommons/ck/issues/1315
+   - added -repro flag to record various info to cmx-repro directory
+     https://github.com/mlcommons/ck/issues/1319
 
 ## V3.1.0
    - simplified and changed process_input function API

--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,4 +1,4 @@
-## V3.1.0.1
+## V3.2.0
    - added `utils.test_input` to test if input has keys
      and report them as error
    - added `prefix_cmx` key to cmr.yaml to customize `cmx pull repo`

--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,3 +1,6 @@
+## V3.1.0.1
+   - added `prefix_cmx` key to cmr.yaml to customize `cmx pull repo`
+
 ## V3.1.0
    - simplified and changed process_input function API
 

--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -10,6 +10,9 @@
      https://github.com/mlcommons/ck/issues/1315
    - added -repro flag to record various info to cmx-repro directory
      https://github.com/mlcommons/ck/issues/1319
+   - print call stack when error > 32 to be able to trace error cause:
+     https://github.com/mlcommons/ck/issues/1320
+     can be combined with -log=debug and -logfile
 
 ## V3.1.0
    - simplified and changed process_input function API

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -2,7 +2,7 @@
 #
 # Written by Grigori Fursin
 
-__version__ = "3.1.0"
+__version__ = "3.1.0.1"
 
 from cmind.core import access
 from cmind.core import x

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -2,7 +2,7 @@
 #
 # Written by Grigori Fursin
 
-__version__ = "3.1.0.1"
+__version__ = "3.2.0"
 
 from cmind.core import access
 from cmind.core import x

--- a/cm/cmind/config.py
+++ b/cm/cmind/config.py
@@ -38,7 +38,7 @@ class Config(object):
 
                      "error_prefix": "CM error:",
                      "info_cli": "cm {action} {automation} {artifact(s)} {flags} @input.yaml @input.json",
-                     "info_clix": "cmx {action} {automation} {artifact(s)} {flags} @input.yaml @input.json",
+                     "info_clix": "cmx {action} {automation} {artifact(s)} {CMX control flags (-)} {CMX automation flags (--)}",
 
                      "default_home_dir": "CM",
 
@@ -64,7 +64,7 @@ class Config(object):
                        "cp":"copy"
                      },
 
-                     "new_repo_requirements": "cmind >= 3.0.0\n",
+                     "new_repo_requirements": "cmind >= 3.1.0\n",
 
                      "cmind_automation":"automation",
 

--- a/cm/cmind/core.py
+++ b/cm/cmind/core.py
@@ -781,7 +781,8 @@ class CM(object):
         # Load info about all CM repositories (to enable search for automations and artifacts)
         if self.repos == None:
             repos = Repos(path = self.repos_path, cfg = self.cfg, 
-                          path_to_internal_repo = self.path_to_cmind_repo)
+                          path_to_internal_repo = self.path_to_cmind_repo,
+                          cmx = True)
 
             r = repos.load()
             if r['return'] >0 : return r

--- a/cm/cmind/repo.py
+++ b/cm/cmind/repo.py
@@ -41,7 +41,7 @@ class Repo:
         self.meta = {}
 
     ############################################################
-    def load(self):
+    def load(self, cmx = False):
         """
         Load CM repository
 
@@ -71,8 +71,15 @@ class Repo:
 
         self.meta = r['meta']
 
-        self.path_prefix = self.meta.get('prefix','')
+        if cmx and self.meta.get('prefix_cmx', '') != '':
+            self.path_prefix = self.meta.get('prefix_cmx','')
+        else:
+            self.path_prefix = self.meta.get('prefix','')
+
         if self.path_prefix is not None and self.path_prefix.strip() !='':
             self.path_with_prefix = os.path.join(self.path, self.path_prefix)
+
+        if os.path.isdir(self.path) and not os.path.isdir(self.path_with_prefix):
+            os.makedirs(self.path_with_prefix)
 
         return {'return':0}

--- a/cm/cmind/repos.py
+++ b/cm/cmind/repos.py
@@ -12,7 +12,7 @@ class Repos:
     CM repositories class
     """
 
-    def __init__(self, path, cfg, path_to_internal_repo = ''):
+    def __init__(self, path, cfg, path_to_internal_repo = '', cmx = False):
         """
         Initialize CM repositories class
 
@@ -48,6 +48,8 @@ class Repos:
         self.full_path_to_repo_paths = ''
 
         self.extra_info = {}
+
+        self.cmx = cmx
 
     ############################################################
     def load(self, init = False):
@@ -128,7 +130,7 @@ class Repos:
                     # Load description
                     repo = Repo(full_path_to_repo, self.cfg)
 
-                    r = repo.load()
+                    r = repo.load(cmx = self.cmx)
                     if r['return']>0 and r['return']!=16: return r
 
                     # Load only if desc exists

--- a/cm/cmind/utils.py
+++ b/cm/cmind/utils.py
@@ -1927,3 +1927,22 @@ def convert_dictionary(d, key, sub = True):
 
     return dd
 
+##############################################################################
+def test_input(i, module):
+    """
+    Test if input has keys and report them as error
+    """
+
+    r = {'return':0}
+
+    if len(i)>0:
+        unknown_keys = i.keys()
+        unknown_keys_str = ', '.join(unknown_keys)
+
+        r =  {'return': 1, 
+              'error': 'unknown input key(s) "{}" in module {}'.format(unknown_keys_str, module),
+              'module': module,
+              'unknown_keys': unknown_keys,
+              'unknown_keys_str': unknown_keys_str}
+
+    return r

--- a/cm/docs/cmx/README.md
+++ b/cm/docs/cmx/README.md
@@ -1,3 +1,14 @@
-# Collective Mind v3 (prototype)
+# Collective Mind v3 aka CMX
+
+We prototype the next generation of CM.
+
+## Documentation
 
 * [Installation (Linux, Windows, MacOS)](install.md)
+
+TBD
+
+
+## Contacts
+
+* Contact the author and tech. lead for more details: [Grigori Fursin](https://cKnowledge.org/gfursin)


### PR DESCRIPTION
I added many important features to CMX pending for a very long:
   - added `utils.test_input` to test if input has keys and report them as error
   - added `prefix_cmx` key to cmr.yaml to customize `cmx pull repo`
   - improved CMX logging (-log and -logfile):  https://github.com/mlcommons/ck/issues/1317
   - print control flags in help (cmx -h | cmx -help):   https://github.com/mlcommons/ck/issues/1318
   - fail if control flag is not recognized:  https://github.com/mlcommons/ck/issues/1315
   - added -repro flag to record various info to cmx-repro directory:  https://github.com/mlcommons/ck/issues/1319
   - print call stack when error > 32 to be able to trace error cause:  https://github.com/mlcommons/ck/issues/1320
     can be combined with -log=debug and -logfile
