### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ across diverse and continuously changing models, data, software and hardware.
 
 CK consists of several sub-projects:
 
-* [Collective Mind framework (CM)](cm) - a very light-weight Python-based framework with minimal dependencies
+* [Collective Mind framework (CM)](cm) - a very lightweight Python-based framework with minimal dependencies
   to help users implement, share and reuse cross-platform automation recipes to 
   build, benchmark and optimize applications on any platform
   with any software and hardware. 


### PR DESCRIPTION
Corrected "light-weight" to "lightweight" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.