### PR TITLE
V3.3.1

### DIFF
--- a/cm/CHANGES.md
+++ b/cm/CHANGES.md
@@ -1,3 +1,7 @@
+## V3.3.1
+   - allow "cm/cmx pull repo {URL}" along with "cm/cmx pull repo --url={URL}" 
+   - CMX: added "automation_full_path" to -log
+
 ## V3.2.9
    - fixed minor bug with JSON console output
    - fixed minor bug with console in cmind.x function

--- a/cm/cmind/__init__.py
+++ b/cm/cmind/__init__.py
@@ -2,7 +2,7 @@
 #
 # Written by Grigori Fursin
 
-__version__ = "3.2.9"
+__version__ = "3.3.1"
 
 from cmind.core import access
 from cmind.core import x

--- a/cm/cmind/core.py
+++ b/cm/cmind/core.py
@@ -1341,6 +1341,9 @@ class CM(object):
             loaded_common_automation = True
 
         # Finalize automation class initialization
+        if not self.logger == None:
+            self.log(f"x automation_full_path: {automation_full_path}", "info")
+
         initialized_automation = loaded_automation_class(self, automation_full_path)
         initialized_automation.meta = automation_meta
         initialized_automation.full_path = automation_full_path

--- a/cm/cmind/repo/automation/repo/module.py
+++ b/cm/cmind/repo/automation/repo/module.py
@@ -66,6 +66,12 @@ class CAutomation(Automation):
         checkout_only = i.get('checkout_only', False)
         skip_zip_parent_dir = i.get('skip_zip_parent_dir', False)
 
+        # Check alias is URL
+        if url == '' and (alias.startswith('https://') or alias.startswith('git@')):
+            url = alias
+            alias = ''
+
+        # Process URL and alias
         if url == '':
             if alias != '':
                 url = self.cmind.cfg['repo_url_prefix']

--- a/cm/requirements.txt
+++ b/cm/requirements.txt
@@ -1,4 +1,5 @@
 pyyaml
 requests
 setuptools
+wheel
 giturlparse

--- a/cm/setup.py
+++ b/cm/setup.py
@@ -94,7 +94,7 @@ setup(
         'install': custom_install
     },
 
-    install_requires=['pyyaml', 'requests', 'setuptools', 'giturlparse'],
+    install_requires=['pyyaml', 'requests', 'setuptools', 'wheel', 'giturlparse'],
 
     entry_points={"console_scripts": [
                       "cmind = cmind.cli:run",


### PR DESCRIPTION
- allow "cm/cmx pull repo {URL}" along with "cm/cmx pull repo --url={URL}" 
- CMX: added "automation_full_path" to -log
